### PR TITLE
2.0.1

### DIFF
--- a/Example/Tests/FunctionHelper.swift
+++ b/Example/Tests/FunctionHelper.swift
@@ -11,8 +11,8 @@ import Nimble
 import Combine
 @testable import HTTPTaskPublisher
 
-func waitForResponse<P: Publisher>(to publisher: P) throws -> Result<(data: Data, response: URLResponse), HTTPURLError> where P.Output == (data: Data, response: HTTPURLResponse), P.Failure == HTTPURLError {
-    var result: Result<(data: Data, response: URLResponse), HTTPURLError>?
+func waitForResponse<P: Publisher>(to publisher: P) throws -> Result<URLResponseOutput, HTTPURLError> where P.Output == HTTPURLResponseOutput, P.Failure == HTTPURLError {
+    var result: Result<URLResponseOutput, HTTPURLError>?
     var cancellable: AnyCancellable?
     waitUntil { done in
         cancellable = publisher.sink { completion in

--- a/Example/Tests/HTTPDataTaskPublisherSpec.swift
+++ b/Example/Tests/HTTPDataTaskPublisherSpec.swift
@@ -13,6 +13,7 @@ import Combine
 @testable import HTTPTaskPublisher
 
 class HTTPDataTaskPublisherSpec: QuickSpec {
+    // swiftlint:disable function_body_length
     override class func spec() {
         var factory: DataTaskFactoryMock!
         var publisher: URLSession.HTTPDataTaskPublisher!
@@ -79,12 +80,13 @@ class HTTPDataTaskPublisherSpec: QuickSpec {
             }
         }
     }
+    // swiftlint:enable function_body_length
 }
 
 // MARK: Test
 
-private func sendRequest(using publisher: URLSession.HTTPDataTaskPublisher) throws -> Result<(data: Data, response: URLResponse), HTTPURLError> {
-    var result: Result<(data: Data, response: URLResponse), HTTPURLError>?
+private func sendRequest(using publisher: URLSession.HTTPDataTaskPublisher) throws -> Result<URLResponseOutput, HTTPURLError> {
+    var result: Result<URLResponseOutput, HTTPURLError>?
     var cancellable: AnyCancellable?
     waitUntil { done in
         cancellable = publisher.sink { completion in
@@ -109,7 +111,7 @@ private func sendRequest(using publisher: URLSession.HTTPDataTaskPublisher) thro
 
 // MARK: Expectation
 
-private func expectToBeDefaultSuccess(for result: Result<(data: Data, response: URLResponse), HTTPURLError>) {
+private func expectToBeDefaultSuccess(for result: Result<URLResponseOutput, HTTPURLError>) {
     switch result {
     case .success:
         return
@@ -118,7 +120,7 @@ private func expectToBeDefaultSuccess(for result: Result<(data: Data, response: 
     }
 }
 
-private func expectToBeDefaultError(for result: Result<(data: Data, response: URLResponse), HTTPURLError>) {
+private func expectToBeDefaultError(for result: Result<URLResponseOutput, HTTPURLError>) {
     switch result {
     case .success:
         fail("result should fail")
@@ -131,12 +133,12 @@ private func expectToBeDefaultError(for result: Result<(data: Data, response: UR
     }
 }
 
-private func expectToBeExpectedError(for result: Result<(data: Data, response: URLResponse), HTTPURLError>) {
+private func expectToBeExpectedError(for result: Result<URLResponseOutput, HTTPURLError>) {
     switch result {
     case .success:
         fail("result should fail")
     case .failure(let error):
-        guard case .failWhileAdapt(_, _) = error else {
+        guard case .failWhileAdapt = error else {
             fail("result should produce expected error but produce \(String(describing: error))")
             return
         }

--- a/Example/Tests/HTTPRetrySpec.swift
+++ b/Example/Tests/HTTPRetrySpec.swift
@@ -86,7 +86,7 @@ class HTTPRetrySpec: QuickSpec {
 
 // MARK: Expectation
 
-private func expectToBeDefaultSuccess(for result: Result<(data: Data, response: URLResponse), HTTPURLError>) {
+private func expectToBeDefaultSuccess(for result: Result<URLResponseOutput, HTTPURLError>) {
     switch result {
     case .success:
         return
@@ -95,7 +95,7 @@ private func expectToBeDefaultSuccess(for result: Result<(data: Data, response: 
     }
 }
 
-private func expectToBeWhileRetryError(for result: Result<(data: Data, response: URLResponse), HTTPURLError>) {
+private func expectToBeWhileRetryError(for result: Result<URLResponseOutput, HTTPURLError>) {
     switch result {
     case .success:
         fail("result should fail")
@@ -111,7 +111,7 @@ private func expectToBeWhileRetryError(for result: Result<(data: Data, response:
     }
 }
 
-private func expectToBeToRetryError(for result: Result<(data: Data, response: URLResponse), HTTPURLError>) {
+private func expectToBeToRetryError(for result: Result<URLResponseOutput, HTTPURLError>) {
     switch result {
     case .success:
         fail("result should fail")
@@ -124,7 +124,7 @@ private func expectToBeToRetryError(for result: Result<(data: Data, response: UR
     }
 }
 
-private func expectToBeExpectedError(for result: Result<(data: Data, response: URLResponse), HTTPURLError>) {
+private func expectToBeExpectedError(for result: Result<URLResponseOutput, HTTPURLError>) {
     switch result {
     case .success:
         fail("result should fail")
@@ -139,7 +139,6 @@ private func expectToBeExpectedError(for result: Result<(data: Data, response: U
 }
 
 private class MockRetrier: HTTPDataTaskRetrier {
-    
     
     var decision: HTTPDataTaskRetryDecision = .drop
     var called: Bool { calledCount > 1 }

--- a/Example/Tests/HTTPValidSpec.swift
+++ b/Example/Tests/HTTPValidSpec.swift
@@ -69,7 +69,7 @@ class HTTPValidSpec: QuickSpec {
 
 // MARK: Expectation
 
-private func expectToBeDefaultSuccess(for result: Result<(data: Data, response: URLResponse), HTTPURLError>) {
+private func expectToBeDefaultSuccess(for result: Result<URLResponseOutput, HTTPURLError>) {
     switch result {
     case .success:
         return
@@ -78,7 +78,7 @@ private func expectToBeDefaultSuccess(for result: Result<(data: Data, response: 
     }
 }
 
-private func expectToBeValidationError(for result: Result<(data: Data, response: URLResponse), HTTPURLError>) {
+private func expectToBeValidationError(for result: Result<URLResponseOutput, HTTPURLError>) {
     switch result {
     case .success:
         fail("result should fail")
@@ -91,7 +91,7 @@ private func expectToBeValidationError(for result: Result<(data: Data, response:
     }
 }
 
-private func expectToBeExpectedError(for result: Result<(data: Data, response: URLResponse), HTTPURLError>) {
+private func expectToBeExpectedError(for result: Result<URLResponseOutput, HTTPURLError>) {
     switch result {
     case .success:
         fail("result should fail")

--- a/Example/Tests/TestDouble.swift
+++ b/Example/Tests/TestDouble.swift
@@ -12,16 +12,16 @@ import Combine
 
 class MockablePublisher: Publisher, HTTPDataTaskDemandable {
     
-    typealias Output = (data: Data, response: HTTPURLResponse)
+    typealias Output = HTTPURLResponseOutput
     typealias Failure = HTTPURLError
     
-    let result: Result<(data: Data, response: HTTPURLResponse), HTTPURLError>
+    let result: Result<HTTPURLResponseOutput, HTTPURLError>
     
-    init(_ result: Result<(data: Data, response: HTTPURLResponse), HTTPURLError>) {
+    init(_ result: Result<HTTPURLResponseOutput, HTTPURLError>) {
         self.result = result
     }
     
-    func receive<S>(subscriber: S) where S : Subscriber, HTTPTaskPublisher.HTTPURLError == S.Failure, (data: Data, response: HTTPURLResponse) == S.Input {
+    func receive<S>(subscriber: S) where S: Subscriber, HTTPTaskPublisher.HTTPURLError == S.Failure, HTTPURLResponseOutput == S.Input {
         let subscription = URLSession.HTTPDataTaskSubscription(publisher: self, subscriber: subscriber)
         subscriber.receive(subscription: subscription)
     }
@@ -47,14 +47,14 @@ extension URLRequest {
 
 class DataTaskFactoryMock: DataTaskPublisherFactory {
     
-    let result: Result<(data: Data, response: URLResponse), URLError>
+    let result: Result<URLResponseOutput, URLError>
     var request: URLRequest?
     
-    init(result: Result<(data: Data, response: URLResponse), URLError>) {
+    init(result: Result<URLResponseOutput, URLError>) {
         self.result = result
     }
     
-    func anyDataTaskPublisher(for request: URLRequest, duplicationHandling: DuplicationHandling) -> Future<(data: Data, response: URLResponse), URLError> {
+    func anyDataTaskPublisher(for request: URLRequest, duplicationHandling: DuplicationHandling) -> Future<URLResponseOutput, URLError> {
         self.request = request
         let result = self.result
         return Future { promise in

--- a/HTTPTaskPublisher/Classes/Base/DataTaskPublisherFactory.swift
+++ b/HTTPTaskPublisher/Classes/Base/DataTaskPublisherFactory.swift
@@ -23,7 +23,7 @@ public enum DuplicationHandling {
     case dropIfDuplicated
 }
 
-private var ongoingRequestKey: String = "ongoingRequestKey"
+private var ongoingRequestKey: UnsafeMutableRawPointer = malloc(1)
 
 extension URLSession: DataTaskPublisherFactory {
     

--- a/HTTPTaskPublisher/Classes/Base/DataTaskPublisherFactory.swift
+++ b/HTTPTaskPublisher/Classes/Base/DataTaskPublisherFactory.swift
@@ -8,8 +8,10 @@
 import Foundation
 import Combine
 
+public typealias URLResponseOutput = (data: Data, response: URLResponse)
+
 public protocol DataTaskPublisherFactory {
-    func anyDataTaskPublisher(for request: URLRequest, duplicationHandling: DuplicationHandling) -> Future<(data: Data, response: URLResponse), URLError>
+    func anyDataTaskPublisher(for request: URLRequest, duplicationHandling: DuplicationHandling) -> Future<URLResponseOutput, URLError>
 }
 
 public enum DuplicationHandling {
@@ -34,7 +36,7 @@ extension URLSession: DataTaskPublisherFactory {
         }
     }
     
-    public func anyDataTaskPublisher(for request: URLRequest, duplicationHandling: DuplicationHandling) -> Future<(data: Data, response: URLResponse), URLError> {
+    public func anyDataTaskPublisher(for request: URLRequest, duplicationHandling: DuplicationHandling) -> Future<URLResponseOutput, URLError> {
         switch duplicationHandling {
         case .useCurrentIfPossible:
             return getPublisher(of: request)
@@ -48,15 +50,15 @@ extension URLSession: DataTaskPublisherFactory {
         return createNewPublisher(for: request)
     }
     
-    private func getPublisher(of request: URLRequest) -> Future<(data: Data, response: URLResponse), URLError> {
+    private func getPublisher(of request: URLRequest) -> Future<URLResponseOutput, URLError> {
         guard let currentPublisher = ongoingRequest[request]?.future else {
             return createNewPublisher(for: request)
         }
         return currentPublisher
     }
     
-    private func createNewPublisher(for request: URLRequest) -> Future<(data: Data, response: URLResponse), URLError> {
-        let future: Future<(data: Data, response: URLResponse), URLError> = .init { promise in
+    private func createNewPublisher(for request: URLRequest) -> Future<URLResponseOutput, URLError> {
+        let future: Future<URLResponseOutput, URLError> = .init { promise in
             self.dataTask(with: request) { data, response, error in
                 if let error {
                     promise(.failure(error.asUrlError))
@@ -76,9 +78,9 @@ extension URLSession: DataTaskPublisherFactory {
 }
 
 struct WeakFutureWrapper {
-    weak var future: Future<(data: Data, response: URLResponse), URLError>?
+    weak var future: Future<URLResponseOutput, URLError>?
     
-    init(future: Future<(data: Data, response: URLResponse), URLError>? = nil) {
+    init(future: Future<URLResponseOutput, URLError>? = nil) {
         self.future = future
     }
 }

--- a/HTTPTaskPublisher/Classes/Base/HTTPDataTaskPublisher.swift
+++ b/HTTPTaskPublisher/Classes/Base/HTTPDataTaskPublisher.swift
@@ -61,7 +61,7 @@ extension URLSession {
     
     public class HTTPDataTaskPublisher: Publisher, HTTPDataTaskSubscribable {
         
-        public typealias Output = (data: Data, response: HTTPURLResponse)
+        public typealias Output = HTTPURLResponseOutput
         public typealias Failure = HTTPURLError
         
         let dataTaskFactory: DataTaskPublisherFactory
@@ -122,7 +122,7 @@ extension URLSession {
         }
     }
     
-    class HTTPDataTaskSubscription<S: Subscriber>: Subscription, HTTPDataTaskReceiver where S.Failure == HTTPURLError, S.Input == (data: Data, response: HTTPURLResponse) {
+    class HTTPDataTaskSubscription<S: Subscriber>: Subscription, HTTPDataTaskReceiver where S.Failure == HTTPURLError, S.Input == HTTPURLResponseOutput {
         
         var publisher: HTTPDataTaskDemandable?
         var subscriber: S?

--- a/HTTPTaskPublisher/Classes/Extensions/Publisher+Extensions.swift
+++ b/HTTPTaskPublisher/Classes/Extensions/Publisher+Extensions.swift
@@ -8,9 +8,11 @@
 import Foundation
 import Combine
 
-extension Publisher where Output == (data: Data, response: URLResponse), Failure == URLError {
+public typealias HTTPURLResponseOutput = (data: Data, response: HTTPURLResponse)
+
+extension Publisher where Output == URLResponseOutput, Failure == URLError {
     
-    func httpResponseOnly() -> AnyPublisher<(data: Data, response: HTTPURLResponse), HTTPURLError> {
+    func httpResponseOnly() -> AnyPublisher<HTTPURLResponseOutput, HTTPURLError> {
         tryMap { output in
             guard let response = output.response as? HTTPURLResponse else {
                 throw HTTPURLError.expectHTTPResponse(data: output.data, response: output.response)

--- a/HTTPTaskPublisher/Classes/Retrier/HTTPClosureRetrier.swift
+++ b/HTTPTaskPublisher/Classes/Retrier/HTTPClosureRetrier.swift
@@ -25,7 +25,7 @@ struct HTTPClosureRetrier: HTTPDataTaskRetrier {
 
 // MARK: Publisher + HTTPClosureAdapter
 
-extension Publisher where Self: HTTPDataTaskDemandable, Output == (data: Data, response: HTTPURLResponse), Failure == HTTPURLError {
+extension Publisher where Self: HTTPDataTaskDemandable, Output == HTTPURLResponseOutput, Failure == HTTPURLError {
     
     public func retryDecision(for retrier: @escaping (HTTPURLError) async throws -> HTTPDataTaskRetryDecision) -> URLSession.HTTPRetry<Self> {
         retrying(using: HTTPClosureRetrier(retrier))

--- a/HTTPTaskPublisher/Classes/Retrier/HTTPClosureRetrier.swift
+++ b/HTTPTaskPublisher/Classes/Retrier/HTTPClosureRetrier.swift
@@ -10,11 +10,9 @@ import Combine
 
 struct HTTPClosureRetrier: HTTPDataTaskRetrier {
     
-    typealias RetrierClosure = (HTTPURLError) async throws -> HTTPDataTaskRetryDecision
+    let retryClosure: (HTTPURLError) async throws -> HTTPDataTaskRetryDecision
     
-    let retryClosure: RetrierClosure
-    
-    init(_ retryClosure: @escaping RetrierClosure) {
+    init(_ retryClosure: @Sendable @escaping (HTTPURLError) async throws -> HTTPDataTaskRetryDecision) {
         self.retryClosure = retryClosure
     }
     
@@ -27,7 +25,7 @@ struct HTTPClosureRetrier: HTTPDataTaskRetrier {
 
 extension Publisher where Self: HTTPDataTaskDemandable, Output == HTTPURLResponseOutput, Failure == HTTPURLError {
     
-    public func retryDecision(for retrier: @escaping (HTTPURLError) async throws -> HTTPDataTaskRetryDecision) -> URLSession.HTTPRetry<Self> {
+    public func retryDecision(for retrier: @Sendable @escaping (HTTPURLError) async throws -> HTTPDataTaskRetryDecision) -> URLSession.HTTPRetry<Self> {
         retrying(using: HTTPClosureRetrier(retrier))
     }
     

--- a/HTTPTaskPublisher/Classes/Validator/HTTPClosureValidator.swift
+++ b/HTTPTaskPublisher/Classes/Validator/HTTPClosureValidator.swift
@@ -26,7 +26,7 @@ struct HTTPClosureValidator: HTTPDataTaskValidator {
 
 // MARK: Publisher + HTTPClosureValidator
 
-extension Publisher where Self: HTTPDataTaskDemandable, Output == (data: Data, response: HTTPURLResponse), Failure == HTTPURLError {
+extension Publisher where Self: HTTPDataTaskDemandable, Output == HTTPURLResponseOutput, Failure == HTTPURLError {
     
     public func validate(_ validator: @escaping (Data, HTTPURLResponse) -> HTTPDataTaskValidation) -> URLSession.HTTPValid<Self> {
         validate(using: HTTPClosureValidator(validator: validator))

--- a/HTTPTaskPublisher/Classes/Validator/HTTPStatusCodeValidator.swift
+++ b/HTTPTaskPublisher/Classes/Validator/HTTPStatusCodeValidator.swift
@@ -14,10 +14,6 @@ struct HTTPStatusCodeValidator: HTTPDataTaskValidator {
     
     let allowedStatusCodes: [Int]
     
-    init(allowedStatusCodes: [Int]) {
-        self.allowedStatusCodes = allowedStatusCodes
-    }
-    
     func httpDataTaskIsValid(for data: Data, response: HTTPURLResponse) -> HTTPDataTaskValidation {
         allowedStatusCodes.contains(response.statusCode)
         ? .valid

--- a/HTTPTaskPublisher/Classes/Validator/HTTPStatusCodeValidator.swift
+++ b/HTTPTaskPublisher/Classes/Validator/HTTPStatusCodeValidator.swift
@@ -27,7 +27,7 @@ struct HTTPStatusCodeValidator: HTTPDataTaskValidator {
 
 // MARK: Publisher + HTTPStatusCodeValidator
 
-extension Publisher where Self: HTTPDataTaskDemandable, Output == (data: Data, response: HTTPURLResponse), Failure == HTTPURLError {
+extension Publisher where Self: HTTPDataTaskDemandable, Output == HTTPURLResponseOutput, Failure == HTTPURLError {
     
     public func allowed(statusCodes: [Int]) -> URLSession.HTTPValid<Self> {
         validate(using: HTTPStatusCodeValidator(allowedStatusCodes: statusCodes))

--- a/HTTPTaskPublisher/Classes/Validator/HTTPValid.swift
+++ b/HTTPTaskPublisher/Classes/Validator/HTTPValid.swift
@@ -10,10 +10,11 @@ import Combine
 
 extension URLSession {
     
-    public class HTTPValid<Upstream: Publisher & HTTPDataTaskDemandable>: HTTPDataTaskSubscribable, Publisher, Subscriber where Upstream.Output == (data: Data, response: HTTPURLResponse), Upstream.Failure == HTTPURLError {
+    public class HTTPValid<Upstream: Publisher & HTTPDataTaskDemandable>: HTTPDataTaskSubscribable, Publisher, Subscriber 
+    where Upstream.Output == HTTPURLResponseOutput, Upstream.Failure == HTTPURLError {
         
-        public typealias Input = (data: Data, response: HTTPURLResponse)
-        public typealias Output = (data: Data, response: HTTPURLResponse)
+        public typealias Input = HTTPURLResponseOutput
+        public typealias Output = HTTPURLResponseOutput
         public typealias Failure = HTTPURLError
         
         let validator: HTTPDataTaskValidator
@@ -27,7 +28,7 @@ extension URLSession {
             upstream.subscribe(self)
         }
         
-        public func receive<S>(subscriber: S) where S : Subscriber, Upstream.Failure == S.Failure, (data: Data, response: HTTPURLResponse) == S.Input {
+        public func receive<S>(subscriber: S) where S: Subscriber, Upstream.Failure == S.Failure, HTTPURLResponseOutput == S.Input {
             let subscription = HTTPDataTaskSubscription(publisher: self, subscriber: subscriber)
             subscriber.receive(subscription: subscription)
         }
@@ -47,7 +48,7 @@ extension URLSession {
             }
         }
         
-        public func receive(_ input: (data: Data, response: HTTPURLResponse)) -> Subscribers.Demand {
+        public func receive(_ input: HTTPURLResponseOutput) -> Subscribers.Demand {
             isWaitingUpstream = false
             let validation = validator.httpDataTaskIsValid(for: input.data, response: input.response)
             switch validation {
@@ -77,7 +78,7 @@ extension URLSession {
 
 // MARK: Publisher + Extensions
 
-extension Publisher where Self: HTTPDataTaskDemandable, Output == (data: Data, response: HTTPURLResponse), Failure == HTTPURLError {
+extension Publisher where Self: HTTPDataTaskDemandable, Output == HTTPURLResponseOutput, Failure == HTTPURLError {
     
     public func validate(using validator: HTTPDataTaskValidator) -> URLSession.HTTPValid<Self> {
         URLSession.HTTPValid(upstream: self, validator: validator)


### PR DESCRIPTION
- Fix line length violation
- Change string to UnsafeMutableRawPointer from malloc to silent
- Remove init that can be synthesized by the compiler
- Mark async closure as Sendable